### PR TITLE
doing safe load for quotes of string

### DIFF
--- a/platform/service/terragrunt.hcl.j2
+++ b/platform/service/terragrunt.hcl.j2
@@ -23,7 +23,7 @@ locals {
 {%-   set stripped_name_prefix = stripped_name_prefix_list | join('') %}
   # Subscription id for the account
 {%-   set accounts = data.config.accounts | replace("'", '"') %}
-  subscriptions = {{ accounts }}
+  subscriptions = {{ accounts | safe }}
   subscription_id = local.subscriptions[local.account_name]
 
   uuid = read_terragrunt_config("${get_terragrunt_dir()}/uuid.hcl").locals.uuid
@@ -85,7 +85,7 @@ remote_state {
 {%- elif data.config.provider == 'aws' %}
   # AWS Profile name
 {%-   set accounts = data.config.accounts | replace("'", '"') %}
-  profiles = {{ accounts }}
+  profiles = {{ accounts | safe }}
   profile_name = local.profiles[local.account_name]
 
   relative_path      = path_relative_to_include()


### PR DESCRIPTION
- accounts is a string of a json object, the quotes in the string needs a safe load to properly work. 