### PR TITLE
Fix blank resource name in rendered template

### DIFF
--- a/platform/pipeline/{{pipeline-resource}}/terragrunt.hcl.j2
+++ b/platform/pipeline/{{pipeline-resource}}/terragrunt.hcl.j2
@@ -12,6 +12,7 @@
 {%-   set ns.provider =  data.config.provider.service %}
 {%- endif %}
 # This file has been generated using the launch-cli
+
 locals {
 
   # Inputs that can be shared across all the child modules
@@ -105,12 +106,12 @@ remote_state {
 {%-   if data.config.remote_state and data.config.remote_state.bucket %}
   bucket          = "{{ data.config.remote_state.bucket}}"
 {%-   else %}
-  bucket          = "${replace(local.naming_prefix, "_", "-")}-{{ resource }}-${local.region}-${local.account_name}-${local.environment_instance}-tfstate-000"
+  bucket          = "${replace(local.naming_prefix, "_", "-")}-{{ ns.resource }}-${local.region}-${local.account_name}-${local.environment_instance}-tfstate-000"
 {%-   endif %}
 {%-   if data.config.remote_state and data.config.remote_state.dynamodb_table %}
   dynamodb_table  = "{{ data.config.remote_state.dynamodb_table}}"
 {%-   else %}
-  dynamodb_table  = "${local.naming_prefix}-{{ resource }}-${local.region}-${local.account_name}-${local.environment_instance}-tfstate-000"
+  dynamodb_table  = "${local.naming_prefix}-{{ ns.resource }}-${local.region}-${local.account_name}-${local.environment_instance}-tfstate-000"
 {%-   endif %}
 }
 


### PR DESCRIPTION
Prior to this update, we'd render a backend.tf like so:

![image](https://github.com/user-attachments/assets/4e1e1b8a-a333-46ef-9615-f1dd2fa6ea66)

Now, the missing resource name appears:

![image](https://github.com/user-attachments/assets/9d80d958-73c0-41ec-b0dd-54e3f8c81b88)
